### PR TITLE
feat(patterns): support linked models

### DIFF
--- a/admin/src/components/CollectionTypeModal.tsx
+++ b/admin/src/components/CollectionTypeModal.tsx
@@ -36,6 +36,7 @@ export default function CollectionTypeModal({
 	const [lastModified, setLastModified] = useState('false');
 	const [thumbnail, setThumbnail] = useState('');
 	const [possibleThumbnailFields, setPossibleThumbnailFields] = useState<any[]>([]);
+	const [populateLinkedModels, setPopulateLinkedModels] = useState('false');
 
 	const [collectionTypes, setCollectionTypes] = useState<CollectionType[]>([]);
 	const [locales, setLocales] = useState<any[]>([]);
@@ -48,6 +49,7 @@ export default function CollectionTypeModal({
 	const frequencyRef = useRef<HTMLInputElement>(null);
 	const lastModifiedRef = useRef<HTMLInputElement>(null);
 	const thumbnailRef = useRef<HTMLInputElement>(null);
+	const populateLinkedModelsRef = useRef<HTMLInputElement>(null);
 
 	const { get, put, post } = getFetchClient();
 
@@ -92,6 +94,7 @@ export default function CollectionTypeModal({
 					lastModified,
 					thumbnail,
 					id: editID,
+					populateLinkedModels,
 				});
 			} else {
 				response = await post(`/${PLUGIN_ID}/admin`, {
@@ -102,6 +105,7 @@ export default function CollectionTypeModal({
 					lastModified,
 					frequency,
 					thumbnail,
+					populateLinkedModels,
 				});
 			}
 
@@ -117,6 +121,7 @@ export default function CollectionTypeModal({
 			setEditID('');
 			setTypeToEdit('');
 			setModalOpen(false);
+			setPopulateLinkedModels('false');
 		} catch (err) {
 			console.error(err);
 			alert('An unexpected error occurred.');
@@ -132,6 +137,7 @@ export default function CollectionTypeModal({
 			setFrequency(typeToEdit.frequency || '');
 			setLastModified(typeToEdit.lastModified || 'false');
 			setThumbnail(typeToEdit.thumbnail || '');
+			setPopulateLinkedModels(typeToEdit.populateLinkedModels || 'false');
 		} else {
 			setType('');
 			setLangcode('');
@@ -141,6 +147,7 @@ export default function CollectionTypeModal({
 			setLastModified('false');
 			setThumbnail('');
 			setEditID('');
+			setPopulateLinkedModels('false');
 		}
 	}, [typeToEdit]);
 
@@ -285,12 +292,36 @@ export default function CollectionTypeModal({
 								<Field.Hint />
 							</Field.Root>
 						</Grid.Item>
+						<Grid.Item>
+							<Field.Root
+								width="100%"
+								hint={
+									"Enable population of linked models to include related data in the URL. " +
+									"Note that this may significantly increase the time required to generate the sitemap."
+								}
+							>
+								<Field.Label>Populate linked models</Field.Label>
+								<SingleSelect
+									name="populateLinkedModels"
+									required
+									onChange={handleSelectChange(setPopulateLinkedModels)}
+									ref={populateLinkedModelsRef}
+									value={populateLinkedModels}
+									placeholder="Select True or False"
+									disabled={type === ''}
+								>
+									<SingleSelectOption value="false">False</SingleSelectOption>
+									<SingleSelectOption value="true">True</SingleSelectOption>
+								</SingleSelect>
+								<Field.Hint />
+							</Field.Root>
+						</Grid.Item>
 					</Grid.Root>
 				</Modal.Body>
 				<Modal.Footer>
 					<Modal.Close>
 						<Button variant="tertiary" onClick={() => {
-							setTypeToEdit('');
+							setTypeToEdit("");
 							setModalOpen(false)
 						}}>Cancel</Button>
 					</Modal.Close>

--- a/server/content-types/strapi-5-sitemap-plugin-content-type/schema.json
+++ b/server/content-types/strapi-5-sitemap-plugin-content-type/schema.json
@@ -38,6 +38,9 @@
 		},
 		"thumbnail": {
 			"type": "string"
+		},
+		"populateLinkedModels": {
+			"type": "string"
 		}
 	}
 }

--- a/server/src/services/service.test.ts
+++ b/server/src/services/service.test.ts
@@ -28,6 +28,12 @@ describe('Sitemap service', () => {
 									priority: 0.1,
 									frequency: 'daily',
 								},
+								{
+									pattern: 'test4/[nested.url]/[url]',
+									type: 'test4',
+									priority: 0.1,
+									frequency: 'daily',
+								},
 							]),
 						};
 					case 'api::test.test':
@@ -50,6 +56,12 @@ describe('Sitemap service', () => {
 							findMany: vi
 								.fn()
 								.mockReturnValue([{ nested: { url: 'parent-url' }, url: 'child-url' }]),
+						};
+					case 'api::test4.test4':
+						return {
+							findMany: vi
+								.fn()
+								.mockReturnValue([{ nested: null, url: 'child-url' }]),
 						};
 					case 'plugin::strapi-5-sitemap-plugin.strapi-5-sitemap-plugin-option':
 						return {
@@ -121,6 +133,11 @@ describe('Sitemap service', () => {
           </url>
           <url>
               <loc>https://example.com/test3/parent-url/child-url</loc>
+              <priority>0.1</priority>
+              <changefreq>daily</changefreq>
+          </url>
+          <url>
+              <loc>https://example.com/test4/child-url</loc>
               <priority>0.1</priority>
               <changefreq>daily</changefreq>
           </url>

--- a/server/src/services/service.test.ts
+++ b/server/src/services/service.test.ts
@@ -22,6 +22,12 @@ describe('Sitemap service', () => {
 									priority: 0.5,
 									frequency: 'daily',
 								},
+								{
+									pattern: 'test3/[nested.url]/[url]',
+									type: 'test3',
+									priority: 0.1,
+									frequency: 'daily',
+								},
 							]),
 						};
 					case 'api::test.test':
@@ -38,6 +44,12 @@ describe('Sitemap service', () => {
 								{ url: null, other: 'other' }, // would generate invalid url
 								{ url: '789', other: null }, // would generate invalid url
 							]),
+						};
+					case 'api::test3.test3':
+						return {
+							findMany: vi
+								.fn()
+								.mockReturnValue([{ nested: { url: 'parent-url' }, url: 'child-url' }]),
 						};
 					case 'plugin::strapi-5-sitemap-plugin.strapi-5-sitemap-plugin-option':
 						return {
@@ -95,7 +107,8 @@ describe('Sitemap service', () => {
 		const normalized = normalizeXml(sitemap);
 		const expected = normalizeXml(`
       <?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      				xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
           <url>
               <loc>https://example.com/test/123</loc>
               <priority>0.5</priority>
@@ -104,6 +117,11 @@ describe('Sitemap service', () => {
           <url>
               <loc>https://example.com/test2/456/other</loc>
               <priority>0.5</priority>
+              <changefreq>daily</changefreq>
+          </url>
+          <url>
+              <loc>https://example.com/test3/parent-url/child-url</loc>
+              <priority>0.1</priority>
               <changefreq>daily</changefreq>
           </url>
           <url>


### PR DESCRIPTION
This pull request adds support for populating linked models when generating sitemaps, allowing nested object references in URL patterns. The main change is the introduction of a new `populateLinkedModels` option in the admin modal and backend logic, which enables fetching related data for more complex URL generation. The implementation includes frontend UI updates, schema changes, service logic enhancements, and new test cases to verify nested model population.

**Feature: Populate Linked Models in Sitemap Generation**
* Added a new `populateLinkedModels` field to the admin modal UI (`CollectionTypeModal.tsx`), including state management, form controls, and reset logic, allowing users to enable or disable this feature for each collection type. [[1]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR39) [[2]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR295-R324)
* Updated the content type schema to include the `populateLinkedModels` property, ensuring the new option is persisted in the backend. (`strapi-5-sitemap-plugin-content-type/schema.json`)

**Backend Logic Enhancements**
* Implemented utility functions `getNestedValue` and `parseTableReferences` in the sitemap service to support nested object references and dynamic population of linked models based on URL pattern placeholders. (`service.ts`)
* Modified the sitemap generation logic to use the new `populateLinkedModels` setting, enabling population of nested models and supporting dot notation in URL patterns for related data.

**Testing and Validation**
* Expanded test coverage in `service.test.ts` to verify correct sitemap output for nested model population and to ensure new XML namespace handling for images. [[1]](diffhunk://#diff-b11ebf00440a2a81c4aadfc49d189985dc67ed2a269f1f554079f3c5f05a6813R25-R36) [[2]](diffhunk://#diff-b11ebf00440a2a81c4aadfc49d189985dc67ed2a269f1f554079f3c5f05a6813R54-R65) [[3]](diffhunk://#diff-b11ebf00440a2a81c4aadfc49d189985dc67ed2a269f1f554079f3c5f05a6813L98-R123) [[4]](diffhunk://#diff-b11ebf00440a2a81c4aadfc49d189985dc67ed2a269f1f554079f3c5f05a6813R134-R143)

**Data Handling**
* Ensured that the new `populateLinkedModels` field is correctly saved, reset, and passed through the backend when creating or editing collection types. [[1]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR97) [[2]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR108) [[3]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR124) [[4]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR140) [[5]](diffhunk://#diff-b8ff3b4f6d2af9263d0a36ad19b4546e20e92f714e57db05cc756644476053bbR150) [[6]](diffhunk://#diff-2b1823132f859d174de2d302b34e8f40cb049d5aec0bc4856eab6c82fb43ca65R293)